### PR TITLE
fix(cli-service): webpack-dev-server doesn't exit on Ctrl+C

### DIFF
--- a/packages/@vue/cli-service/lib/commands/serve.js
+++ b/packages/@vue/cli-service/lib/commands/serve.js
@@ -261,7 +261,7 @@ module.exports = (api, options) => {
 
     // fix: webpack-dev-server doesn't exit on Ctrl+C
     ;['SIGINT', 'SIGTERM'].forEach(signal => {
-      process.on(signal, () => exitProcess)
+      process.on(signal, exitProcess)
     })
 
     if (args.stdin) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Underlying tools
- [ ] Other, please describe:

<!--
Note:
When submitting documentation PRs, please target the `master` branch (https://cli.vuejs.org) or `next` branch (https://next.cli.vuejs.org)
When submitting coding PRs, please target the `dev` branch.
-->

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

**Other information:**
